### PR TITLE
Fix sed invocation

### DIFF
--- a/arachne.sh
+++ b/arachne.sh
@@ -63,8 +63,8 @@ rename() {
    done
 
    for f in `find . -type f | grep -v '\./\.git'`; do
-       sed -i '' s:$from:$to:g $f
-       sed -i '' s:$from_alt:$to_alt:g $f
+       sed -i -e "s:$from:$to:g" $f
+       sed -i -e "s:$from_alt:$to_alt:g" $f
    done
 
 }


### PR DESCRIPTION
I ran into error with the specified sed call on OSX.

> uname -a
Darwin monoid.h.c6e.de 16.3.0 Darwin Kernel Version 16.3.0: Sun Oct 23 14:50:01 PDT 2016; root:xnu-3789.30.76~4/RELEASE_X86_64 x86_64

> sed --version
sed (GNU sed) 4.3

> bash --version
GNU bash, version 3.2.57(1)-release (x86_64-apple-darwin16)

Fhis patches fixed it for me.