### PR TITLE
Only sed non-binary files

### DIFF
--- a/arachne.sh
+++ b/arachne.sh
@@ -63,9 +63,12 @@ rename() {
    done
 
    for f in `find . -type f | grep -v '\./\.git'`; do
-       sed -i.bak -e "s:$from:$to:g" $f
-       sed -i.bak -e "s:$from_alt:$to_alt:g" $f
-       rm $f.bak
+       charset=`file -b --mime $f | cut -d ' ' -f 2 | cut -d = -f 2`
+       if [ "$charset" != "binary" ]; then
+           sed -i.bak -e "s:$from:$to:g" $f
+           sed -i.bak -e "s:$from_alt:$to_alt:g" $f
+           rm $f.bak
+       fi
    done
 
 }


### PR DESCRIPTION
This fixes issues on macOS with sed erroring out when acting on binary files (images, .DS_Store files) in the arachne template.

`file -b --mime {file}` outputs `<mimetype>; charset=<charset>` which I extract with `cut` and check to see if it's binary or not before performing the `sed`

I've tested the updated script on macOS, Debian 9 (Stretch), CentOS

Fixes #6 